### PR TITLE
fix(VIP-858): upgrade follow-redirects and pin GHA actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,19 +16,19 @@ jobs:
     container:
       image: node:22
     steps:
-      - uses: act10ns/slack@v1
+      - uses: act10ns/slack@87c73aef9f8838eb6feae81589a6b1487a4a9e08 # v1
         with:
           status: starting
           channel: '#gitactivity'
         if: always()
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 0
       - run: npm install
       - name: Run Tests
         run: make test
-      - uses: act10ns/slack@v1
+      - uses: act10ns/slack@87c73aef9f8838eb6feae81589a6b1487a4a9e08 # v1
         with:
           status: ${{ job.status }}
           channel: '#gitactivity'
@@ -40,19 +40,19 @@ jobs:
     if: ${{ always() && contains(join(needs.*.result, ','), 'success') && contains(github.ref_name, 'preview') }}
     needs: [ test ]
     steps:
-      - uses: act10ns/slack@v1
+      - uses: act10ns/slack@87c73aef9f8838eb6feae81589a6b1487a4a9e08 # v1
         with:
           status: starting
           channel: '#gitactivity'
         if: always()
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 0
       - run: npm install
       - name: Run Build
         run: make build
-      - uses: act10ns/slack@v1
+      - uses: act10ns/slack@87c73aef9f8838eb6feae81589a6b1487a4a9e08 # v1
         with:
           status: ${{ job.status }}
           channel: '#gitactivity'
@@ -67,20 +67,20 @@ jobs:
     if: ${{ always() && contains(join(needs.*.result, ','), 'success') && startsWith(github.ref_name, 'v') }}
     needs: [ test ]
     steps:
-      - uses: act10ns/slack@v1
+      - uses: act10ns/slack@87c73aef9f8838eb6feae81589a6b1487a4a9e08 # v1
         with:
           status: starting
           channel: '#gitactivity'
         if: always()
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 0
       - run: npm install
       - name: Run Build
         run: make build
       - name: Setup Node for NPM
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
@@ -88,7 +88,7 @@ jobs:
         run: npm install -g npm@11.5.1
       - name: Publish to NPM
         run: npm publish --provenance --access public
-      - uses: act10ns/slack@v1
+      - uses: act10ns/slack@87c73aef9f8838eb6feae81589a6b1487a4a9e08 # v1
         with:
           status: ${{ job.status }}
           channel: '#gitactivity'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blockchyp/blockchyp-js",
-  "version": "2.28.0",
+  "version": "2.30.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@blockchyp/blockchyp-js",
-      "version": "2.28.0",
+      "version": "2.30.1",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.27.0",
@@ -279,7 +279,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2834,7 +2833,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -3456,7 +3454,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3578,7 +3575,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3754,9 +3750,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -6085,7 +6081,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -7500,7 +7495,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.30.2.tgz",
       "integrity": "sha512-0pE4RQ4UQi1jKY6p7u6i1Tkzqmu+d+/tHS7Q7rKunWLB9WyilBTpHHpXzPNMDj5hTbK0B0PTLSz07yqMBiF6xg==",
       "requires": {
-        "follow-redirects": "^1.15.4",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
@@ -7810,7 +7805,6 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.0.tgz",
       "integrity": "sha512-tbydkR/CxfMwelN0vwdP/pLkDwyAASZ+VfWm4EOwlB6SWhx1sYnWLqo8N5j0rAzPfzfRaxt0mM/4wPU/Su84RQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -8286,7 +8280,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.1.tgz",
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8363,8 +8356,7 @@
           "version": "8.15.0",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
           "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-          "dev": true,
-          "peer": true
+          "dev": true
         },
         "acorn-jsx": {
           "version": "5.3.2",
@@ -8487,9 +8479,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ=="
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="
     },
     "for-each": {
       "version": "0.3.5",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,9 @@
     "terser": "^5.36.0",
     "uuid": "^3.3.3"
   },
+  "overrides": {
+    "follow-redirects": "^1.16.0"
+  },
   "dependencies": {
     "@babel/runtime": "^7.27.0",
     "@noble/curves": "^1.6.0",


### PR DESCRIPTION
## Summary

- **GHSA-r4q5-vmmm-2653 (high)**: `follow-redirects` was pinned transitively at `1.15.9` via `axios`. Added an `overrides` block in `package.json` to force `follow-redirects >= 1.16.0`, which resolves the vulnerability. Lock file updated to `1.16.0`.
- **SAST (high) — unpinned GHA actions**: All `uses:` references in `.github/workflows/main.yml` were pinned to immutable commit SHAs:
  - `act10ns/slack@v1` → `87c73aef9f8838eb6feae81589a6b1487a4a9e08`
  - `actions/checkout@v3` → `f43a0e5ff2bd294095638e18286ca9a3d1956744`
  - `actions/setup-node@v4` → `49933ea5288caeca8642d1e84afbd3f7d6820020`

## Test plan

- [ ] CI passes on this branch (npm install + tests)
- [ ] Verify `npm audit` no longer reports GHSA-r4q5-vmmm-2653
- [ ] Confirm workflow still triggers correctly for push/tag events